### PR TITLE
Add continue_from_prev_binlog option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ password = "replpwd"
 port = 3306
 replicate_server_id = 100
 username = "repl"
+#continue_from_prev_binlog = false
 
 [replica]
 charset = "utf8mb4"

--- a/config.go
+++ b/config.go
@@ -15,7 +15,8 @@ const (
 
 type SourceConfig struct {
 	ConnInfo
-	ReplicateServerId uint32 `toml:"replicate_server_id"`
+	ReplicateServerId      uint32 `toml:"replicate_server_id"`
+	ContinueFromPrevBinlog bool   `toml:"continue_from_prev_binlog"`
 }
 
 type ReplicaConfig struct {

--- a/config.toml.example
+++ b/config.toml.example
@@ -5,6 +5,7 @@ password = ""
 port = 13306
 replicate_server_id = 100
 username = "root"
+#continue_from_prev_binlog = false
 
 [replica]
 charset = "utf8mb4"


### PR DESCRIPTION
Add `continue_from_prev_binlog` option.
When this option is enabled, synchronization will start from the end of the previous binlog.

```
mysql> show master logs;
+-------------------------+-----------+
| Log_name                | File_size |
+-------------------------+-----------+
| f4ab41ddeba9-bin.000001 |       177 |
| f4ab41ddeba9-bin.000002 |   3053418 |
| f4ab41ddeba9-bin.000003 |      1052 |
| f4ab41ddeba9-bin.000004 |       217 |
| f4ab41ddeba9-bin.000005 |       217 |
| f4ab41ddeba9-bin.000006 |       217 | <-- start position
| f4ab41ddeba9-bin.000007 |       466 |
+-------------------------+-----------+
```
