### PR TITLE
continue_from_prev_binlog -> binlog_buffer_num

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ password = "replpwd"
 port = 3306
 replicate_server_id = 100
 username = "repl"
-#continue_from_prev_binlog = false
+#binlog_buffer_num = 0
 
 [replica]
 charset = "utf8mb4"

--- a/config.go
+++ b/config.go
@@ -15,8 +15,8 @@ const (
 
 type SourceConfig struct {
 	ConnInfo
-	ReplicateServerId      uint32 `toml:"replicate_server_id"`
-	ContinueFromPrevBinlog bool   `toml:"continue_from_prev_binlog"`
+	ReplicateServerId uint32 `toml:"replicate_server_id"`
+	BinlogBufferNum   uint32 `toml:"binlog_buffer_num"`
 }
 
 type ReplicaConfig struct {

--- a/config.toml.example
+++ b/config.toml.example
@@ -5,7 +5,7 @@ password = ""
 port = 13306
 replicate_server_id = 100
 username = "root"
-#continue_from_prev_binlog = false
+#binlog_buffer_num = 0
 
 [replica]
 charset = "utf8mb4"


### PR DESCRIPTION
Enabled to specify how long ago binlog to start.

```
mysql> show master logs;
+-------------------------+-----------+
| Log_name                | File_size |
+-------------------------+-----------+
| f4ab41ddeba9-bin.000001 |       177 | <-- binlog_buffer_num: 6
| f4ab41ddeba9-bin.000002 |   3053418 | <-- binlog_buffer_num: 5
| f4ab41ddeba9-bin.000003 |      1052 | <-- binlog_buffer_num: 4
| f4ab41ddeba9-bin.000004 |       217 | <-- binlog_buffer_num: 3
| f4ab41ddeba9-bin.000005 |       217 | <-- binlog_buffer_num: 2
| f4ab41ddeba9-bin.000006 |       217 | <-- binlog_buffer_num: 1
| f4ab41ddeba9-bin.000007 |       466 |
+-------------------------+-----------+