### PR TITLE
Quote columns in where clause

### DIFF
--- a/sql_builder.go
+++ b/sql_builder.go
@@ -135,7 +135,9 @@ func (sqlBld *SQLBuilder) buildWhereClause(values []interface{}) (string, []inte
 	builder.WriteString("WHERE ")
 
 	for i, v := range values {
+		builder.WriteString("`")
 		builder.WriteString(sqlBld.Table.ColumnNames[i])
+		builder.WriteString("`")
 
 		if v != nil {
 			builder.WriteString(" = ?")


### PR DESCRIPTION
binrpt generates WHERE clauses with unquoted column names. This causes failures in replicating some update and delete operations when columns have names that collide with reserved words. This PR fixes the issue by quoting column names in WHERE clauses.